### PR TITLE
fix: use proper AES-256-GCM decryptKey instead of legacy XOR

### DIFF
--- a/app/api/ask-ai/route.ts
+++ b/app/api/ask-ai/route.ts
@@ -40,15 +40,9 @@ import {
   createRateLimitIdentifier,
   API_RATE_LIMITS,
 } from "@/lib/api-rate-limit";
+import { decryptKey } from "@/lib/api-keys";
 
-// Helper to decrypt API keys
-function decryptKey(encrypted: string): string {
-  const secret = process.env.API_KEYS_SECRET || process.env.NEXTAUTH_SECRET || "default-secret";
-  const buffer = Buffer.from(encrypted, "base64");
-  const secretBuffer = Buffer.from(secret);
-  const decrypted = buffer.map((byte, i) => byte ^ secretBuffer[i % secretBuffer.length]);
-  return Buffer.from(decrypted).toString("utf-8");
-}
+
 
 // Create AI client based on provider
 function createClient(


### PR DESCRIPTION
Fixes #4: The API route was using a duplicate local decryptKey function with insecure legacy XOR encryption instead of importing the proper AES-256-GCM implementation from lib/api-keys.ts.

This caused API authentication failures when keys were encrypted with the new format, as the local function could not decrypt them properly.